### PR TITLE
Check Serializable Exceptions

### DIFF
--- a/taskmaster-service-helper/src/main/java/com/github/bordertech/taskmaster/service/CallType.java
+++ b/taskmaster-service-helper/src/main/java/com/github/bordertech/taskmaster/service/CallType.java
@@ -1,7 +1,7 @@
 package com.github.bordertech.taskmaster.service;
 
 /**
- * The service call type to invoke.
+ * The cached service call type to invoke.
  *
  * @author Jonathan Austin
  * @since 1.0.0

--- a/taskmaster-service-helper/src/main/java/com/github/bordertech/taskmaster/service/ExceptionUtil.java
+++ b/taskmaster-service-helper/src/main/java/com/github/bordertech/taskmaster/service/ExceptionUtil.java
@@ -1,0 +1,53 @@
+package com.github.bordertech.taskmaster.service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Exception Helper Util.
+ */
+public final class ExceptionUtil {
+
+	/**
+	 * Private constructor.
+	 */
+	private ExceptionUtil() {
+		// Do nothing
+	}
+
+	/**
+	 * Check the exception is Serializable (sometimes they arent).
+	 *
+	 * @param excp the original exception to check
+	 * @return the original exception if Serializable or a ServiceException with the original exception message
+	 */
+	public static Exception getSerializableException(final Exception excp) {
+		if (isSerializableException(excp)) {
+			return excp;
+		}
+		// Wrap exception as a Service Exception
+		return new ServiceException(excp.getMessage() + " Original exception [" + excp.getClass().getName() + "] not Serializable.");
+	}
+
+	/**
+	 *
+	 * Determine if the Exception is Serializable (as sometimes they arent).
+	 *
+	 * @param excp the Exception to check is serializable
+	 * @return true if Exception is serializable
+	 */
+	public static boolean isSerializableException(final Exception excp) {
+		try {
+			ByteArrayOutputStream bos = new ByteArrayOutputStream();
+			ObjectOutputStream os = new ObjectOutputStream(bos);
+			os.writeObject(excp);
+			bos.toByteArray();
+			// Serializable
+			return true;
+		} catch (Exception ex) {
+			// Not Serializable
+			return false;
+		}
+	}
+
+}

--- a/taskmaster-service-helper/src/main/java/com/github/bordertech/taskmaster/service/ResultHolder.java
+++ b/taskmaster-service-helper/src/main/java/com/github/bordertech/taskmaster/service/ResultHolder.java
@@ -13,7 +13,7 @@ import java.io.Serializable;
  * @author Jonathan Austin
  * @since 1.0.0
  */
-public class ResultHolder<M, T> implements Serializable {
+public class ResultHolder<M extends Serializable, T extends Serializable> implements Serializable {
 
 	private final M metaData;
 	private final T result;
@@ -38,6 +38,10 @@ public class ResultHolder<M, T> implements Serializable {
 	 * @param exception the exception that occurred
 	 */
 	public ResultHolder(final M metaData, final Exception exception) {
+		// Exception must be provided
+		if (exception == null) {
+			throw new IllegalArgumentException("An exception must be provided.");
+		}
 		this.metaData = metaData;
 		this.result = null;
 		this.exception = exception;

--- a/taskmaster-service-helper/src/main/java/com/github/bordertech/taskmaster/service/ServiceAction.java
+++ b/taskmaster-service-helper/src/main/java/com/github/bordertech/taskmaster/service/ServiceAction.java
@@ -1,5 +1,7 @@
 package com.github.bordertech.taskmaster.service;
 
+import java.io.Serializable;
+
 /**
  * Invoke a service interface.
  *
@@ -8,7 +10,7 @@ package com.github.bordertech.taskmaster.service;
  * @author Jonathan Austin
  * @since 1.0.0
  */
-public interface ServiceAction<S, T> {
+public interface ServiceAction<S extends Serializable, T extends Serializable> {
 
 	/**
 	 * Invoke service call.

--- a/taskmaster-service-helper/src/main/java/com/github/bordertech/taskmaster/service/ServiceHelper.java
+++ b/taskmaster-service-helper/src/main/java/com/github/bordertech/taskmaster/service/ServiceHelper.java
@@ -1,6 +1,7 @@
 package com.github.bordertech.taskmaster.service;
 
 import com.github.bordertech.taskmaster.RejectedTaskException;
+import java.io.Serializable;
 import javax.cache.Cache;
 import javax.cache.expiry.Duration;
 
@@ -23,7 +24,7 @@ public interface ServiceHelper {
 	 * @param <T> the service response
 	 * @return the result or null if still processing
 	 */
-	<S, T> ResultHolder<S, T> checkASyncResult(final Cache<String, ResultHolder> cache, final String cacheKey);
+	<S extends Serializable, T extends Serializable> ResultHolder<S, T> checkASyncResult(final Cache<String, ResultHolder> cache, final String cacheKey);
 
 	/**
 	 * Provide a default result holder cache with the default duration.
@@ -61,11 +62,11 @@ public interface ServiceHelper {
 	 * @return the result or null if still processing
 	 * @throws RejectedTaskException if the task cannot be scheduled for execution
 	 */
-	<S, T> ResultHolder<S, T> handleAsyncServiceCall(final Cache<String, ResultHolder> cache, final String cacheKey,
+	<S extends Serializable, T extends Serializable> ResultHolder<S, T> handleAsyncServiceCall(final Cache<String, ResultHolder> cache, final String cacheKey,
 			final S criteria, final ServiceAction<S, T> action) throws RejectedTaskException;
 
 	/**
-	 * Handle an async service call.
+	 * Handle an async service call with a designated thread pool.
 	 *
 	 * @param cache the result holder cache
 	 * @param cacheKey the key for the result holder
@@ -77,7 +78,7 @@ public interface ServiceHelper {
 	 * @return the result or null if still processing
 	 * @throws RejectedTaskException if the task cannot be scheduled for execution
 	 */
-	<S, T> ResultHolder<S, T> handleAsyncServiceCall(final Cache<String, ResultHolder> cache, final String cacheKey,
+	<S extends Serializable, T extends Serializable> ResultHolder<S, T> handleAsyncServiceCall(final Cache<String, ResultHolder> cache, final String cacheKey,
 			final S criteria, final ServiceAction<S, T> action, final String pool) throws RejectedTaskException;
 
 	/**
@@ -92,7 +93,7 @@ public interface ServiceHelper {
 	 * @param <T> the service response
 	 * @return the result
 	 */
-	<S, T> ResultHolder<S, T> handleCachedServiceCall(final Cache<String, ResultHolder> cache, final String cacheKey,
+	<S extends Serializable, T extends Serializable> ResultHolder<S, T> handleCachedServiceCall(final Cache<String, ResultHolder> cache, final String cacheKey,
 			final S criteria, final ServiceAction<S, T> action);
 
 	/**
@@ -104,11 +105,11 @@ public interface ServiceHelper {
 	 * @param <T> the service response
 	 * @return the result
 	 */
-	<S, T> ResultHolder<S, T> handleServiceCall(final S criteria, final ServiceAction<S, T> action);
+	<S extends Serializable, T extends Serializable> ResultHolder<S, T> handleServiceCall(final S criteria, final ServiceAction<S, T> action);
 
 	/**
 	 *
-	 * Handle a cached service call.
+	 * Handle a cached service call with a particular call type.
 	 *
 	 * @param cache the result holder cache
 	 * @param cacheKey the key for the result holder
@@ -120,12 +121,12 @@ public interface ServiceHelper {
 	 * @return the result or null if still processing an async call
 	 * @throws RejectedTaskException if the task cannot be scheduled for execution
 	 */
-	<S, T> ResultHolder<S, T> handleServiceCallType(final Cache<String, ResultHolder> cache, final String cacheKey,
+	<S extends Serializable, T extends Serializable> ResultHolder<S, T> handleServiceCallType(final Cache<String, ResultHolder> cache, final String cacheKey,
 			final S criteria, final ServiceAction<S, T> action, final CallType callType) throws RejectedTaskException;
 
 	/**
 	 *
-	 * Handle a cached service call.
+	 * Handle a cached service call with a particular call type and predefined pool.
 	 *
 	 * @param cache the result holder cache
 	 * @param cacheKey the key for the result holder
@@ -138,7 +139,7 @@ public interface ServiceHelper {
 	 * @return the result or null if still processing an async call
 	 * @throws RejectedTaskException if the task cannot be scheduled for execution
 	 */
-	<S, T> ResultHolder<S, T> handleServiceCallType(final Cache<String, ResultHolder> cache, final String cacheKey,
+	<S extends Serializable, T extends Serializable> ResultHolder<S, T> handleServiceCallType(final Cache<String, ResultHolder> cache, final String cacheKey,
 			final S criteria, final ServiceAction<S, T> action, final CallType callType, final String pool) throws RejectedTaskException;
 
 }


### PR DESCRIPTION
Sometimes an Exception and its Original Exception is not serializable and cannot be cached.

This change checks an Exception is Serializable before using it in the ResultHolder. Closes #4.

